### PR TITLE
Fix for the Return key when using the custom keyboards with UITextFields...

### DIFF
--- a/iOS Keyboards Example/iOS Custom Keyboards.xcodeproj/project.xcworkspace/xcshareddata/iOS Custom Keyboards.xccheckout
+++ b/iOS Keyboards Example/iOS Custom Keyboards.xcodeproj/project.xcworkspace/xcshareddata/iOS Custom Keyboards.xccheckout
@@ -2,35 +2,37 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>IDESourceControlProjectFavoriteDictionaryKey</key>
+	<false/>
 	<key>IDESourceControlProjectIdentifier</key>
-	<string>A7B8C652-9EA8-4270-8F49-D3CAC750FB6C</string>
+	<string>2C2255DD-97CF-4CCB-85D7-554732FED3AC</string>
 	<key>IDESourceControlProjectName</key>
 	<string>iOS Custom Keyboards</string>
 	<key>IDESourceControlProjectOriginsDictionary</key>
 	<dict>
-		<key>963DEA8E-DCAF-4500-94AB-B4142609B18F</key>
-		<string>https://github.com/kulpreetchilana/Custom-iOS-Keyboards.git</string>
+		<key>DD978A3A-9EF3-4C3F-9546-FC9EBF95BE97</key>
+		<string>https://github.com/vanderneut/Custom-iOS-Keyboards.git</string>
 	</dict>
 	<key>IDESourceControlProjectPath</key>
 	<string>iOS Keyboards Example/iOS Custom Keyboards.xcodeproj/project.xcworkspace</string>
 	<key>IDESourceControlProjectRelativeInstallPathDictionary</key>
 	<dict>
-		<key>963DEA8E-DCAF-4500-94AB-B4142609B18F</key>
+		<key>DD978A3A-9EF3-4C3F-9546-FC9EBF95BE97</key>
 		<string>../../..</string>
 	</dict>
 	<key>IDESourceControlProjectURL</key>
-	<string>https://github.com/kulpreetchilana/Custom-iOS-Keyboards.git</string>
+	<string>https://github.com/vanderneut/Custom-iOS-Keyboards.git</string>
 	<key>IDESourceControlProjectVersion</key>
 	<integer>110</integer>
 	<key>IDESourceControlProjectWCCIdentifier</key>
-	<string>963DEA8E-DCAF-4500-94AB-B4142609B18F</string>
+	<string>DD978A3A-9EF3-4C3F-9546-FC9EBF95BE97</string>
 	<key>IDESourceControlProjectWCConfigurations</key>
 	<array>
 		<dict>
 			<key>IDESourceControlRepositoryExtensionIdentifierKey</key>
 			<string>public.vcs.git</string>
 			<key>IDESourceControlWCCIdentifierKey</key>
-			<string>963DEA8E-DCAF-4500-94AB-B4142609B18F</string>
+			<string>DD978A3A-9EF3-4C3F-9546-FC9EBF95BE97</string>
 			<key>IDESourceControlWCCName</key>
 			<string>Custom-iOS-Keyboards</string>
 		</dict>

--- a/iPad/PKCustomKeyboard.m
+++ b/iPad/PKCustomKeyboard.m
@@ -130,7 +130,10 @@
         // official UITextField documentation: "A UITextField object is a control
         // that displays editable text and sends an action message to a target
         // object when the user presses the return button."
-        [[(UITextField *)self.textView delegate] textFieldShouldReturn:(UITextField *)self.textView];
+        if ([[(UITextField *)self.textView delegate] respondsToSelector:@selector(textFieldShouldReturn:)])
+        {
+            [[(UITextField *)self.textView delegate] textFieldShouldReturn:(UITextField *)self.textView];
+        }
     }
 }
 

--- a/iPad/PKCustomKeyboard.m
+++ b/iPad/PKCustomKeyboard.m
@@ -113,13 +113,25 @@
 
 /* IBActions for Keyboard Buttons */
 
-- (IBAction)returnPressed:(id)sender {
+- (IBAction)returnPressed:(id)sender
+{
     [[UIDevice currentDevice] playInputClick];
-	[self.textView insertText:@"\n"];
+
 	if ([self.textView isKindOfClass:[UITextView class]])
+    {
+        [self.textView insertText:@"\n"];
 		[[NSNotificationCenter defaultCenter] postNotificationName:UITextViewTextDidChangeNotification object:self.textView];
+    }
 	else if ([self.textView isKindOfClass:[UITextField class]])
-		[[NSNotificationCenter defaultCenter] postNotificationName:UITextFieldTextDidChangeNotification object:self.textView];
+    {
+        // -- Erik van der Neut, 24/06/2014: --
+        // When typing text into a TextField, the Enter key should trigger the
+        // textFieldShouldReturn: delegate method instead of adding \n.  From the
+        // official UITextField documentation: "A UITextField object is a control
+        // that displays editable text and sends an action message to a target
+        // object when the user presses the return button."
+        [[(UITextField *)self.textView delegate] textFieldShouldReturn:(UITextField *)self.textView];
+    }
 }
 
 - (IBAction)shiftPressed:(id)sender {

--- a/iPhone:iPod/PMCustomKeyboard.m
+++ b/iPhone:iPod/PMCustomKeyboard.m
@@ -181,7 +181,10 @@ enum {
         // official UITextField documentation: "A UITextField object is a control
         // that displays editable text and sends an action message to a target
         // object when the user presses the return button."
-        [[(UITextField *)self.textView delegate] textFieldShouldReturn:(UITextField *)self.textView];
+        if ([[(UITextField *)self.textView delegate] respondsToSelector:@selector(textFieldShouldReturn:)])
+        {
+            [[(UITextField *)self.textView delegate] textFieldShouldReturn:(UITextField *)self.textView];
+        }
     }
 }
 

--- a/iPhone:iPod/PMCustomKeyboard.m
+++ b/iPhone:iPod/PMCustomKeyboard.m
@@ -164,13 +164,25 @@ enum {
 
 /* IBActions for Keyboard Buttons */
 
-- (IBAction)returnPressed:(id)sender {
+- (IBAction)returnPressed:(id)sender
+{
     [[UIDevice currentDevice] playInputClick];
-	[self.textView insertText:@"\n"];
+
 	if ([self.textView isKindOfClass:[UITextView class]])
+    {
+        [self.textView insertText:@"\n"];
 		[[NSNotificationCenter defaultCenter] postNotificationName:UITextViewTextDidChangeNotification object:self.textView];
+    }
 	else if ([self.textView isKindOfClass:[UITextField class]])
-		[[NSNotificationCenter defaultCenter] postNotificationName:UITextFieldTextDidChangeNotification object:self.textView];
+    {
+        // -- Erik van der Neut, 24/06/2014: --
+        // When typing text into a TextField, the Enter key should trigger the
+        // textFieldShouldReturn: delegate method instead of adding \n.  From the
+        // official UITextField documentation: "A UITextField object is a control
+        // that displays editable text and sends an action message to a target
+        // object when the user presses the return button."
+        [[(UITextField *)self.textView delegate] textFieldShouldReturn:(UITextField *)self.textView];
+    }
 }
 
 - (IBAction)shiftPressed:(id)sender {


### PR DESCRIPTION
.... In that case, the return key should trigger the textFieldShouldReturn: delegate method. -- Erik
